### PR TITLE
Credentials are not included on show single article in client

### DIFF
--- a/src/components/SingleArticle.jsx
+++ b/src/components/SingleArticle.jsx
@@ -18,8 +18,14 @@ const SingleArticle = (props) => {
   const article = useSelector((state) => state.articles.activeArticle);
 
   const chooseArticle = async () => {
+    let headers = JSON.parse(localStorage.getItem("J-tockAuth-Storage"));
+    headers = {
+      ...headers,
+      "Content-type": "application/json",
+      Accept: "application/json",
+    };
     try {
-      const response = await axios.get(`/articles/${id}`);
+      const response = await axios.get(`/articles/${id}`, { headers: headers });
       dispatch({ type: "SET_ACTIVE_ARTICLE", payload: response.data.article });
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
[BUGFIX Credentials are not included on show single article in client](https://www.pivotaltracker.com/story/show/173213314)

Add headers to show single article request.
Before even subscribers would only get 300 chars from backend despite logged in.